### PR TITLE
Allow to mount Admin namespace on a specific path.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Ektar::Engine.routes.draw do
     resources :users, path: I18n.t("routes.users"), except: [:edit, :update]
   end
 
-  namespace :admin do
+  namespace :admin, path: Ektar.configuration.admin_path do
     resources :users, path: I18n.t("routes.users"), only: [:new, :index, :destroy]
     resources :invitations, path: I18n.t("routes.invitations"), only: [:new, :create]
     resources :select_plan, only: [:new, :create]

--- a/lib/ektar.rb
+++ b/lib/ektar.rb
@@ -28,7 +28,7 @@ module Ektar
     # It sets the `:host` attribute of the `javascript_pack_tag` helper.
     attr_accessor :webpacker_host, :title, :organization_username, :organization_password,
       :session_name, :session_expiration, :session_domain, :password_retain_count, :root_app_path, :sign_in_path,
-      :sign_out_path, :rails_root, :secret_key
+      :sign_out_path, :rails_root, :secret_key, :admin_path
 
     def initialize
       @title = "Ektar administration"
@@ -43,6 +43,7 @@ module Ektar
       @rails_root = nil
       @session_domain = nil
       @secret_key = nil
+      @admin_path = "/admin"
     end
   end
 

--- a/lib/generators/ektar/install/templates/initializer.rb
+++ b/lib/generators/ektar/install/templates/initializer.rb
@@ -7,5 +7,6 @@ Ektar.configure do |config|
   config.root_app_path = "/"
   config.rails_root = Rails.root
   config.session_domain = :all
+  config.admin_path = "/admin"
 end
 


### PR DESCRIPTION
When Ektar is mounted at "/admin", navigating to users gives a path like "/admin/admin/users" which is odd.

With the new admin_path setting a path can be especified, ex: mounting Ektar at "/admin" and the "admin_path" setting set as "/" will render the url for users as "/admin/users".